### PR TITLE
Windows compiler fixes

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -40,10 +40,13 @@ LOCALES = $(patsubst %.po, %.mo, $(wildcard po/*.po))
 
 all: $(TARGET)
 
-purplegwa.a: purplegwa.go purplegwa-media.go
+purplegwa.a: purplegwa.go purplegwa-media.go gwa-to-purple.o
 	$(GO) get github.com/Rhymen/go-whatsapp
 	$(GO) get github.com/skip2/go-qrcode
 	$(GO) build -buildmode=c-archive -o purplegwa.a purplegwa.go purplegwa-media.go
+
+gwa-to-purple.o: gwa-to-purple.c
+	$(WIN32_CC) -c -o $@ $^ -g -ggdb
 
 $(TARGET): $(PURPLE_C_FILES) $(PURPLE_COMPAT_FILES) purplegwa.a
 	$(WIN32_CC) $(CFLAGS) $(CPPFLAGS) -shared -o $@ $^ $(LDFLAGS)  $(INCLUDES) -Ipurple2compat -g -ggdb

--- a/gwa-to-purple.c
+++ b/gwa-to-purple.c
@@ -1,0 +1,7 @@
+#include <stdint.h>
+
+void gowhatsapp_process_message_bridge(uintptr_t pc, void *gwamsg)
+{
+	(void) pc;
+	(void) gwamsg;
+}

--- a/libgowhatsapp.c
+++ b/libgowhatsapp.c
@@ -292,6 +292,14 @@ gowhatsapp_read_cb(gpointer userdata, gint source, PurpleInputCondition cond)
         free(gwamsg.wid);
 }
 
+#ifdef _WIN32
+#ifndef _O_BINARY
+#define _O_BINARY 0x8000
+#endif
+
+#define pipe(a) _pipe((a), 256, _O_BINARY)
+#endif
+
 void
 gowhatsapp_login(PurpleAccount *account)
 {

--- a/purplegwa.go
+++ b/purplegwa.go
@@ -57,6 +57,10 @@ struct gowhatsapp_message {
 
 struct gowhatsapp_session {
 };
+
+extern void gowhatsapp_process_message_bridge(uintptr_t pc, void * gwamsg);
+#cgo LDFLAGS: gwa-to-purple.o
+
 */
 import "C"
 
@@ -95,6 +99,7 @@ type waHandler struct {
 	messageSize        C.size_t // TODO: find out how to determine the size in cgo
 	downloadsDirectory string
 	doDownloads        bool
+	connID             C.uintptr_t
 }
 
 /*
@@ -151,6 +156,7 @@ func bool_to_Cchar(b bool) C.char {
 	}
 }
 
+
 /*
  * Forwards a message to the front-end.
  */
@@ -160,7 +166,8 @@ func (handler *waHandler) presentMessage(message MessageAggregate) {
 		handler.wac.Read(message.info.RemoteJid, message.info.Id) // mark message as "displayed"
 	}
 	cmessage := convertMessage(message)
-	C.write(handler.pipeFileDescriptor, unsafe.Pointer(&cmessage), handler.messageSize)
+	//C.write(handler.pipeFileDescriptor, unsafe.Pointer(&cmessage), handler.messageSize)
+	C.gowhatsapp_process_message_bridge(handler.connID, unsafe.Pointer(&cmessage))
 }
 
 /*
@@ -287,6 +294,7 @@ func gowhatsapp_go_login(
 		messageSize:        messageSize,
 		downloadsDirectory: C.GoString(downloadsDirectory),
 		doDownloads:        doDownloads,
+		connID:             connID,
 	}
 	waHandlers[connID] = &handler
 	var session *whatsapp.Session


### PR DESCRIPTION
So Win32 doesn't have a `pipe()` function, but there is a similar `_pipe()`.  This gets the plugin compiling on Windows, but I would appreciate any Windows users out there to test it. :)