### PR TITLE
Store session in password to support BitlBee

### DIFF
--- a/gwa-to-purple.c
+++ b/gwa-to-purple.c
@@ -29,6 +29,13 @@ gowhatsapp_account_get_string(void *account, const char *name, const char *defau
     return 0;
 }
 
+const char *
+gowhatsapp_account_get_password(void *account)
+{
+    (void) account;
+    return 0;
+}
+
 int 
 gowhatsapp_account_get_bool(void *account, const char *name, int default_value)
 {


### PR DESCRIPTION
Account settings in Purple don't get saved in BitlBee, which means
BitlBee users need to reauthenticate every time they log in.

Purple does support changing the password in BitlBee using a set
password signal. Change session storage so that all keys are stored as a
space-separated string in the password field that can be persisted in
BitlBee.

--

At the moment this completely replaces the original session store mechanism. Let me know if it should be an option instead.

Also, i'd be happier if `gowhatsapp_go_decode_session_from_password` and `gowhatsapp_encode_session_as_password` were in the same file as they rely on matching encodings. However, my attempts to create a Go function to call from C just left me with a plugin that wouldn't load. Couldn't see what i was missing.

This is an implementation of @EionRobb's comment in #27.