### PR TITLE
Use architecture of machine build runs on for CPack .deb

### DIFF
--- a/scripts/cpack.cmake
+++ b/scripts/cpack.cmake
@@ -15,9 +15,12 @@ if (NOT ${CPACK_GENERATOR} STREQUAL "DEB")
     # CPACK_GENERATOR can be overridden on command-line
     message(WARNING "cpack genarator other than DEB has not been tested.")
 endif()
-# For now, we won't be doing any cross-compiling, so specifying amd64 here will cover most cases.
-# If you have a different processor and need to cross-compile, say, ARM, then this won't build the package you need until it's modified.
-set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
+# For now, we won't be doing any cross-compiling
+execute_process(
+    COMMAND dpkg --print-architecture
+    OUTPUT_VARIABLE CPACK_DEBIAN_PACKAGE_ARCHITECTURE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
 set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}_${VERSION}_${CPACK_DEBIAN_PACKAGE_ARCHITECTURE}")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)


### PR DESCRIPTION
The Debian .deb architecture was hardcoded to amd64, so when building on other architectures, the .deb file had the wrong architecture unless a manual edit was made. This detects the architecture using dpkg. It still doesn't handle cross-compiling.