### PR TITLE
Build on macOS

### DIFF
--- a/glue/CMakeLists.txt
+++ b/glue/CMakeLists.txt
@@ -25,10 +25,14 @@ add_dependencies(${TARGET_NAME} libwhatsmeow)
 
 target_compile_definitions(${TARGET_NAME} PRIVATE PLUGIN_VERSION=${VERSION})
 target_include_directories(${TARGET_NAME} PRIVATE ${GO_WHATSAPP_INCLUDE_DIRS} ${PURPLE_INCLUDE_DIRS} ${PIXBUF_INCLUDE_DIRS} ${OPUSFILE_INCLUDE_DIRS})
+target_link_directories(${TARGET_NAME} PRIVATE ${PURPLE_LIBRARY_DIRS} ${PIXBUF_LIBRARY_DIRS})
 target_link_libraries(${TARGET_NAME} PRIVATE ${GO_WHATSAPP_LIBRARIES} ${PURPLE_LIBRARIES} ${PIXBUF_LIBRARIES} ${OPUSFILE_LINK_LIBRARIES})
 set_target_properties(${TARGET_NAME} PROPERTIES PREFIX "lib")
 if (WIN32 AND CMAKE_C_COMPILER_ID STREQUAL GNU AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.7.2) # might actually work without this up to 7.1.0, but I did not check
     target_link_options(${TARGET_NAME} PRIVATE "-static-libgcc")
+endif()
+if (APPLE)
+    target_link_libraries(${TARGET_NAME} PRIVATE "-framework CoreFoundation" "-framework Security" resolv)
 endif()
 
 if (WIN32)

--- a/scripts/go.cmake
+++ b/scripts/go.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20) # for cmake_path
 
-if (NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang"))
+if (NOT (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID STREQUAL "Clang" OR CMAKE_C_COMPILER_ID STREQUAL "AppleClang"))
   message(FATAL_ERROR "This project uses cgo which is incompatible with anything but the Clang or GNU C Compiler (see https://github.com/golang/go/issues/36283). Your compiler is ${CMAKE_C_COMPILER_ID}.")
 endif()
 


### PR DESCRIPTION
Hi, I have to make those changes to be able to compile the plugin on a Mac m1. The changes were made by claude code, but they are only 5 lines, not an AI slop I guess :)


  This branch makes the plugin build cleanly on macOS (tested on Apple Silicon with Homebrew). Three changes were needed.

  ### 1. `scripts/go.cmake` — accept `AppleClang`

  CMake reports three different compiler IDs that all share the Clang/GCC ABI: `GNU` (gcc), `Clang` (upstream LLVM, e.g. `brew install llvm`), and `AppleClang` (the `clang` shipped with Xcode Command Line Tools). The existing guard only allowed the first
   two, so the build aborted on macOS with a `FATAL_ERROR` before any code was compiled. `cgo` works fine with AppleClang — the check was a false negative. Adding `AppleClang` to the accepted list fixes this.

  ### 2. `glue/CMakeLists.txt` — pass `*_LIBRARY_DIRS` to the linker

  `pkg-config` splits its output into two CMake variables: `*_LIBRARIES` (library names → `-l…`) and `*_LIBRARY_DIRS` (search paths → `-L…`). The build was only consuming `*_LIBRARIES`. On most Linux distributions this works by accident because
  libpurple/gdk-pixbuf live under `/usr/lib`, which the linker searches by default. On macOS with Homebrew, the libraries live under `/opt/homebrew/lib` and `~/.local/lib` — non-default paths — so the link step fails with `ld: library 'purple3' not
  found`. Adding `target_link_directories(... ${PURPLE_LIBRARY_DIRS} ${PIXBUF_LIBRARY_DIRS})` forwards the `-L` flags that `pkg-config` already computed.

  ### 3. `glue/CMakeLists.txt` — link Apple frameworks and `libresolv`

  The Go runtime on Darwin pulls in symbols from three system components that are not surfaced through any `pkg-config` package:

  - **`-framework CoreFoundation`** — Core Foundation types (`CFString`, `CFArray`, …) used by the Go runtime for time zone, cert store, and similar plumbing.
  - **`-framework Security`** — Keychain / Secure Transport APIs used by `crypto/tls` to validate certificates against the system trust store.
  - **`-lresolv`** — `libresolv` provides `res_*()` DNS resolver functions used by Go's `net` package.

  Without these, linking the final `.dylib` fails with `Undefined symbols for architecture arm64: _CFArrayCreateMutable, _SecKeychainCopyDefault, _res_search, …`. On Linux these are part of glibc or transitively linked via existing pkg-config deps, so
  nothing extra is needed; on macOS, system APIs live in **frameworks** (CoreFoundation, Security) or auxiliary libraries (resolv) that must be requested explicitly.

  The whole block is guarded by `if (APPLE)` so Linux and Windows builds are unaffected.

  ### Summary

  | Problem | Root cause | Fix |
  |---|---|---|
  | `FATAL_ERROR` from CMake | `AppleClang` not in compiler allowlist | Add `AppleClang` to the check |
  | `ld: library 'purple3' not found` | Homebrew paths not in default linker search | Pass `*_LIBRARY_DIRS` to `target_link_directories` |
  | `Undefined symbols: _CFArrayCreateMutable, _res_search, …` | Darwin needs explicit framework / system-lib references | Add CoreFoundation, Security, resolv when `APPLE` |

