### PR TITLE
Send PNG files as image messages

### DIFF
--- a/send_file.go
+++ b/send_file.go
@@ -44,7 +44,7 @@ func (handler *Handler) send_file_bytes(recipient types.JID, isGroup bool, data 
 	handler.log.Infof("Attachment mime type is %s.", mimetype)
 	// TODO: redundant implementation in send_link_message. merge.
 	switch mimetype {
-	case "image/jpeg":
+	case "image/jpeg", "image/png":
 		msg, err = handler.send_file_image(data, mimetype)
 	case "application/ogg", "audio/ogg":
 		opusfile_info := C.opusfile_get_info(C.CBytes(data), C.size_t(len(data)))

--- a/send_message.go
+++ b/send_message.go
@@ -223,8 +223,8 @@ func (handler *Handler) send_link_message(recipient types.JID, isGroup bool, lin
 	mimetype := http.DetectContentType(data) // do not trust the server. he is stupid.
 	// TODO: redundant implementation in send_file_bytes. merge.
 	switch mimetype {
-	case "image/jpeg":
-		// send jpeg as ImageMessage
+	case "image/jpeg", "image/png":
+		// send jpeg or png as ImageMessage
 		// no checks here
 		purple_display_system_message(handler.account, recipient.ToNonAD().String(), isGroup, "Compatible file detected. Forwarding as image message…")
 		msg, err = handler.send_file_image(data, mimetype)


### PR DESCRIPTION
PNG files are currently sent as document messages. WhatsApp accepts them as image messages just like JPEG, so this adds `image/png` to the mime type switch in `send_file_bytes` and to the redundant switch in `send_link_message`.

Tested by sending a PNG file to a contact: it now arrives as a regular image message (with preview) instead of a document.