### PR TITLE
Suggest original file name when receiving files via the transfer mechanism

### DIFF
--- a/glue/handle_attachment.c
+++ b/glue/handle_attachment.c
@@ -84,7 +84,14 @@ static void download_via_xfer_mechanism(gowhatsapp_message_t *gwamsg) {
     }
     
     PurpleXfer * xfer = purple_xfer_new(gwamsg->account, PURPLE_XFER_RECEIVE, sender);
-    char *filename = g_strdup_printf("%s%s%s", gwamsg->hash_hex, gwamsg->filename, gwamsg->extension);
+    char *filename = NULL;
+    if (gwamsg->filename != NULL && gwamsg->filename[0]) {
+        // suggest the original file name (documents have one)
+        filename = g_strdup_printf("%s%s", gwamsg->filename, gwamsg->extension);
+    } else {
+        // fall back to the content hash for nameless media
+        filename = g_strdup_printf("%s%s", gwamsg->hash_hex, gwamsg->extension);
+    }
     purple_xfer_set_filename(xfer, filename);
     g_free(filename);
     purple_xfer_set_size(xfer, gwamsg->filesize);


### PR DESCRIPTION
When receiving a file via the xfer mechanism, the suggested file name is currently the content hash with the original name appended, e.g. `9f8e7d…6a5binvoice.pdf`. This prefers the original file name when the message carries one (document messages do) and keeps the hash as fall-back for nameless media such as images and voice messages.

Tested by receiving a document: the save dialog now suggests `invoice.pdf`. Media without a file name still get the hash-based name as before.