### PR TITLE
Do not create buddies for group JIDs

### DIFF
--- a/glue/blist.c
+++ b/glue/blist.c
@@ -33,6 +33,11 @@ PurpleBuddy * gowhatsapp_ensure_buddy_in_blist(PurpleAccount *account, const cha
         return NULL;
     }
 
+    if (purple_str_has_suffix(identifier, "@g.us")) {
+        // groups are represented by chats. a buddy would offer a direct conversation with the group JID, which cannot work.
+        return NULL;
+    }
+
     PurpleBuddy *buddy = purple_blist_find_buddy(account, identifier);
 
     if (!buddy) {


### PR DESCRIPTION
The contact list supplied by whatsmeow can contain group JIDs. `gowhatsapp_ensure_buddy_in_blist` currently turns those into buddies, so groups show up in the buddy list twice: as a chat and as a pseudo-contact. Opening the pseudo-contact starts a direct conversation with the group JID, which cannot work.

This skips `@g.us` identifiers the same way `@lid` identifiers are already skipped. Groups keep appearing as chats via `gowhatsapp_ensure_group_chat_in_blist`.

Tested with an account that is a member of several groups: group JIDs no longer show up as contacts after reconnecting; the groups keep appearing as chats.