### PR TITLE
Send typing notifications

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -84,6 +84,14 @@ func gowhatsapp_go_logout(account *PurpleAccount) {
 	}
 }
 
+//export gowhatsapp_go_send_typing
+func gowhatsapp_go_send_typing(account *PurpleAccount, who *C.char, typing C.int) {
+	handler, ok := handlers[account]
+	if ok {
+		go handler.send_typing(C.GoString(who), Cint_to_bool(typing))
+	}
+}
+
 //export gowhatsapp_go_send_message
 func gowhatsapp_go_send_message(account *PurpleAccount, who *C.char, message *C.char, is_group C.int) int {
 	handler, ok := handlers[account]

--- a/glue/gowhatsapp.h
+++ b/glue/gowhatsapp.h
@@ -66,6 +66,7 @@ void gowhatsapp_for_all_buddies(PurpleAccount *account, void(*func)(PurpleAccoun
 
 // send_message
 int gowhatsapp_send_im(PurpleConnection *pc, const gchar *who, const gchar *message, PurpleMessageFlags flags);
+unsigned int gowhatsapp_send_typing(PurpleConnection *pc, const gchar *who, PurpleTypingState state);
 int gowhatsapp_send_chat(PurpleConnection *pc, int id, const gchar *message, PurpleMessageFlags flags);
 
 // handle_attachment

--- a/glue/init.c
+++ b/glue/init.c
@@ -130,6 +130,7 @@ static PurplePluginProtocolInfo prpl_info = {
     .tooltip_text = gowhatsapp_tooltip_text,
     // file transfer
     .new_xfer = gowhatsapp_new_xfer,
+    .send_typing = gowhatsapp_send_typing,
     .send_file = gowhatsapp_send_file,
     #if PURPLE_VERSION_CHECK(2,14,0)
     .chat_send_file = gowhatsapp_chat_send_file,

--- a/glue/presence.c
+++ b/glue/presence.c
@@ -146,3 +146,11 @@ void gowhatsapp_request_profile_picture(PurpleAccount *account, PurpleBuddy *bud
         gowhatsapp_go_request_profile_picture(account, buddy->name, (char *)picture_date, (char *)picture_id); // cgo does not suport const
     }
 }
+/*
+ * purple wants to signal a typing state change to the remote user.
+ */
+unsigned int gowhatsapp_send_typing(PurpleConnection *pc, const gchar *who, PurpleTypingState state) {
+    PurpleAccount *account = purple_connection_get_account(pc);
+    gowhatsapp_go_send_typing(account, (char *)who, state == PURPLE_TYPING);
+    return 0; // no need to call serv_send_typing again while state is unchanged
+}

--- a/presence.go
+++ b/presence.go
@@ -72,3 +72,22 @@ func (handler *Handler) subscribe_presence(who string) {
 		handler.log.Warnf("Unable to subscribe for presence updates of %s.", jid.String())
 	}
 }
+
+/*
+ * Informs the other party this user started or stopped composing a message.
+ */
+func (handler *Handler) send_typing(who string, typing bool) {
+	recipient, err := types.ParseJID(who)
+	if err != nil {
+		handler.log.Warnf("send_typing: %v is not a valid JID: %v", who, err)
+		return
+	}
+	state := types.ChatPresencePaused
+	if typing {
+		state = types.ChatPresenceComposing
+	}
+	err = handler.client.SendChatPresence(context.Background(), recipient, state, types.ChatPresenceMediaText)
+	if err != nil {
+		handler.log.Warnf("send_typing failed: %v", err)
+	}
+}


### PR DESCRIPTION
The plugin displays incoming typing notifications, but never sends any: the `send_typing` operation is not implemented, so the remote side never sees "typing…" while a Pidgin user is composing.

This wires libpurple's `send_typing` through to whatsmeow's `SendChatPresence` (composing on `PURPLE_TYPING`, paused otherwise). libpurple's global "send typing notifications" preference keeps working as the opt-out.

Tested against a phone: the chat shows "typing…" while composing in the client and clears it when the input is emptied or the message is sent.